### PR TITLE
Sort classes and modules in overviews

### DIFF
--- a/mkdoxy/templates/classes.jinja2
+++ b/mkdoxy/templates/classes.jinja2
@@ -4,7 +4,7 @@
 {% for letter, children in dictionary.items() %}
 ## {{letter}}
 
-{% for node in children -%}
+{% for node in children|sort(attribute='name_short') -%}
 * [**{{node.name_short}}**]({{node.url}})
 {% if node.parent.is_language -%}
  ([**{{node.parent.name_long}}**]({{node.parent.url}}))

--- a/mkdoxy/templates/modules.jinja2
+++ b/mkdoxy/templates/modules.jinja2
@@ -3,7 +3,7 @@
 
 {% if nodes|length > 0 %}
 Here is a list of all modules:
-{% for node in nodes recursive %}
+{% for node in nodes|sort(attribute='title') recursive %}
 {% if node.is_group %}
 * [**{{node.title}}**]({{node.url}}) {{node.brief}}
 {% if node.has_children %}


### PR DESCRIPTION
When you have a few more classes, it becomes appearent that they are in random order, sorted by letter, but I  have about 20 classes starting with 'A' for example, that's confusing.
The same is true for modules, they were not sorted at all.